### PR TITLE
Cache.copilot

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -15,56 +15,108 @@ const cacheExt = ".gob"
 
 var errInvalidID = errors.New("invalid id")
 
-type convoCache struct {
-	dir string
+type CacheType string
+
+const (
+	ConversationCache CacheType = "conversations"
+)
+
+// Cache represents a generic cache that can store any type
+type Cache[T any] struct {
+	baseDir string
+	cType   CacheType
 }
 
-func newCache(dir string) *convoCache {
-	return &convoCache{dir}
+// NewCache creates a new cache instance
+func NewCache[T any](baseDir string, cacheType CacheType) (*Cache[T], error) {
+	cacheDir := filepath.Join(baseDir, string(cacheType))
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create cache directory: %w", err)
+	}
+	return &Cache[T]{
+		baseDir: baseDir,
+		cType:   cacheType,
+	}, nil
 }
 
-func (c *convoCache) read(id string, messages *[]openai.ChatCompletionMessage) error {
+func (c *Cache[T]) cacheDir() string {
+	return filepath.Join(c.baseDir, string(c.cType))
+}
+
+func (c *Cache[T]) Read(id string, readFn func(io.Reader) error) error {
 	if id == "" {
 		return fmt.Errorf("read: %w", errInvalidID)
 	}
-	file, err := os.Open(filepath.Join(c.dir, id+cacheExt))
+	file, err := os.Open(filepath.Join(c.cacheDir(), id+cacheExt))
 	if err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
 	defer file.Close() //nolint:errcheck
 
-	if err := decode(file, messages); err != nil {
+	if err := readFn(file); err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
 	return nil
 }
 
-func (c *convoCache) write(id string, messages *[]openai.ChatCompletionMessage) error {
+func (c *Cache[T]) Write(id string, writeFn func(io.Writer) error) error {
 	if id == "" {
 		return fmt.Errorf("write: %w", errInvalidID)
 	}
 
-	file, err := os.Create(filepath.Join(c.dir, id+cacheExt))
+	file, err := os.Create(filepath.Join(c.cacheDir(), id+cacheExt))
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	defer file.Close() //nolint:errcheck
 
-	if err := encode(file, messages); err != nil {
+	if err := writeFn(file); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 
 	return nil
 }
 
-func (c *convoCache) delete(id string) error {
+func (c *Cache[T]) Delete(id string) error {
 	if id == "" {
 		return fmt.Errorf("delete: %w", errInvalidID)
 	}
-	if err := os.Remove(filepath.Join(c.dir, id+cacheExt)); err != nil {
+	if err := os.Remove(filepath.Join(c.cacheDir(), id+cacheExt)); err != nil {
 		return fmt.Errorf("delete: %w", err)
 	}
 	return nil
+}
+
+// convoCache wraps Cache for backward compatibility
+type convoCache struct {
+	cache *Cache[[]openai.ChatCompletionMessage]
+}
+
+func newCache(dir string) *convoCache {
+	cache, err := NewCache[[]openai.ChatCompletionMessage](dir, ConversationCache)
+	if err != nil {
+		// maintain backward compatibility by handling error silently
+		return nil
+	}
+	return &convoCache{
+		cache: cache,
+	}
+}
+
+func (c *convoCache) read(id string, messages *[]openai.ChatCompletionMessage) error {
+	return c.cache.Read(id, func(r io.Reader) error {
+		return decode(r, messages)
+	})
+}
+
+func (c *convoCache) write(id string, messages *[]openai.ChatCompletionMessage) error {
+	return c.cache.Write(id, func(w io.Writer) error {
+		return encode(w, messages)
+	})
+}
+
+func (c *convoCache) delete(id string) error {
+	return c.cache.Delete(id)
 }
 
 var _ chatCompletionReceiver = &cachedCompletionStream{}
@@ -76,6 +128,7 @@ type cachedCompletionStream struct {
 }
 
 func (c *cachedCompletionStream) Close() error { return nil }
+
 func (c *cachedCompletionStream) Recv() (openai.ChatCompletionStreamResponse, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -101,6 +154,7 @@ func (c *cachedCompletionStream) Recv() (openai.ChatCompletionStreamResponse, er
 	}
 
 	c.read++
+
 	return openai.ChatCompletionStreamResponse{
 		Choices: []openai.ChatCompletionStreamChoice{
 			{

--- a/cache.go
+++ b/cache.go
@@ -207,7 +207,7 @@ func (c *ExpiringCache[T]) Read(id string, readFn func(io.Reader) error) error {
 
 	if expiresAt < time.Now().Unix() {
 		os.Remove(matches[0])
-		return fmt.Errorf("cache expired")
+		return os.ErrNotExist
 	}
 
 	file, err := os.Open(matches[0])

--- a/config.go
+++ b/config.go
@@ -230,7 +230,7 @@ func ensureConfig() (Config, error) {
 	}
 
 	if c.CachePath == "" {
-		c.CachePath = filepath.Join(xdg.DataHome, "mods", "conversations")
+		c.CachePath = filepath.Join(xdg.DataHome, "mods")
 	}
 
 	if err := os.MkdirAll(c.CachePath, 0o700); err != nil { //nolint:mnd

--- a/main.go
+++ b/main.go
@@ -310,7 +310,7 @@ func main() {
 	}
 
 	cache = newCache(config.CachePath)
-	db, err = openDB(filepath.Join(config.CachePath, "mods.db"))
+	db, err = openDB(filepath.Join(config.CachePath, "conversations", "mods.db"))
 	if err != nil {
 		handleError(modsError{err, "Could not open database."})
 		os.Exit(1)


### PR DESCRIPTION
This pull request introduces significant changes to the caching mechanism in the codebase, including the implementation of a generic cache and an expiring cache, as well as updates to related tests and configurations.

### Cache system improvements:

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042L18-R121): Introduced a generic `Cache` type to handle different cache types and operations, replacing the previous `convoCache`. Added a new `ExpiringCache` type to support cache entries with expiration times. [[1]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042L18-R121) [[2]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R169-R253)
* [`cache_test.go`](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R128-R216): Added tests for the new `ExpiringCache` type to ensure proper functionality for writing, reading, and handling expired cache entries.

### Configuration updates:

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L233-R233): Updated the default cache path to a more general directory, removing the specific "conversations" subdirectory.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L313-R313): Adjusted the database path to reflect the updated cache directory structure.

### Integration with Copilot:

* [`copilot.go`](diffhunk://#diff-458af75f479d120c6a67cc8de8f4c8488fcdfd0b7175b29191beff1fee01c71dR120-R130): Integrated the new `ExpiringCache` for caching Copilot access tokens, ensuring tokens are reused if valid and cached correctly. [[1]](diffhunk://#diff-458af75f479d120c6a67cc8de8f4c8488fcdfd0b7175b29191beff1fee01c71dR120-R130) [[2]](diffhunk://#diff-458af75f479d120c6a67cc8de8f4c8488fcdfd0b7175b29191beff1fee01c71dR161-R168)

### Miscellaneous:

* Added necessary imports to support new functionality, such as `strconv`, `strings`, and `time`. [[1]](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R9-R12) [[2]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1R12) [[3]](diffhunk://#diff-458af75f479d120c6a67cc8de8f4c8488fcdfd0b7175b29191beff1fee01c71dR6)